### PR TITLE
build: homepage value should be the repo name

### DIFF
--- a/jm-glass/package.json
+++ b/jm-glass/package.json
@@ -2,7 +2,7 @@
   "name": "jm-glass",
   "version": "0.1.0",
   "private": true,
-  "homepage": "/pazel-io/jmusic",
+  "homepage": "/jmusic",
   "dependencies": {
     "@emotion/core": "^11.0.0",
     "@emotion/react": "^11.1.4",


### PR DESCRIPTION
GitHub pages urls looks like user.github.io/repo-name, so we need to make sure all our relative URLs are prefixed by /repo-name.